### PR TITLE
Updated gradle and testing dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
+        // TODO: update to latest after idea 2017.2 is released
         classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.mobidevelop.robovm:robovm-gradle-plugin:2.3.0'
     }
@@ -26,8 +27,8 @@ allprojects {
         gsonVersion = '2.8.0'
         guiceVersion = '4.1.0'
         junitVersion = '4.12'
-        mockitoVersion = '2.3.7'
-        truthVersion = '0.31'
+        mockitoVersion = '2.7.22'
+        truthVersion = '0.32'
     }
 
     repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Resolves #33.

- Android plugin for Gradle not updated since it breaks instant run with idea 2017.1.
- Updated Gradle version limited to 3.3 since 3.5 breaks running the app (NoClassDefFound error)